### PR TITLE
fix: consent to all cookies before logging in

### DIFF
--- a/instapy/login_util.py
+++ b/instapy/login_util.py
@@ -242,6 +242,15 @@ def login_user(
     ig_homepage = "https://www.instagram.com"
     web_address_navigator(browser, ig_homepage)
 
+    for element in browser.find_elements_by_tag_name('button'):
+        if element.text.strip().lower() == 'accept all':
+            logger.info("Clicking accept all cookies button ...")
+            element.click()
+            logger.info("Sleeping 4 seconds ...")
+            sleep(4)
+            break
+
+
     cookie_file = "{0}{1}_cookie.pkl".format(logfolder, username)
     cookie_loaded = None
     login_state = None


### PR DESCRIPTION
## Description

Instagram displays a cookie consent message before we can login. This fix clicks the "accept all cookies" button before moving on.

Fixes # (issue)

#6234 

## How Has This Been Tested?

Its now possible to login

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project, `black -t py34`
- [x] My changes generate no new warnings
