### PR TITLE
setup.py - update project_homepage to https://github.com/InstaPy/InstaPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ The **goal** of this file is explaining to the users of our project the notable 
 
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_
 
+## [0.6.17] - 2022-01-19 - [Unreleased]
+
+### Fixed
+
+- Fixed project homepage to [InstaPy](https://github.com/InstaPy/InstaPy)
+
+## [0.6.16] - 2021-12-11
+
+### Added
+
+- Added filter in `extract_text_from_element()` for non-username elements.
+
+### Fixed
+
+- Fixed `is_private_profile()` when 'NoneType' object is not subscriptable
+- Fixed `find_element*()` to `find_element()`
 
 ## [0.6.15] - 2021-12-02
 
@@ -40,7 +56,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
-- Change the ip data supplier to https://freegeoip.app/ from https://seeip.org/
+- Change the ip data supplier to <https://freegeoip.app/> from <https://seeip.org/>
 
 ## [0.6.13] - 2020-12-30
 
@@ -105,12 +121,15 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [0.6.11] - 2020-09-25
 
 ### Added
+
 - Use random tag list for `session.like_by_tags`
 
 ### Changed
+
 - General log rotation, gecko driver log in user directory, comments in 80 chars
 
 ### Fixed
+
 - Unfollowing of users that haven't posted anything
 - `get_links` xpath for yet another change
 - Path for Obtaining user id
@@ -186,7 +205,6 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Small typos in documentation
 - Firefox Proxy error
 
-
 ## [0.6.4] - 2019-09-15
 
 ### Fixed
@@ -194,7 +212,6 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - prettyfied code
 - fixed onetap account page on login
 - fix minor bug in unfollow function
-
 
 ## [0.6.3] - 2019-09-08
 
@@ -213,7 +230,6 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - skip_top_posts function
 - Backup plan for graphql additional / shared data
 
-
 ## [0.6.2] - 2019-08-30
 
 ### Added
@@ -224,7 +240,6 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - Login xpath update
-
 
 ## [0.6.1] - 2019-08-12
 
@@ -238,7 +253,6 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix an issue with JSON file state creation
 - Fix Get Query Hash function to work on all Python 3.x versions
 - Fix Unfollow with option nonFollowers
-
 
 ## [0.6.0] - 2019-08-12
 
@@ -651,7 +665,7 @@ _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
-- Remove https://i.instagram.com/api/v1/users/{}/info/ as it not working and killing the unfollow with error.
+- Remove <https://i.instagram.com/api/v1/users/{}/info/> as it not working and killing the unfollow with error.
 - Fix logging uncertain having no userid nor time log, will be important for sync feature.
 - Fix get active users when Video have no likes button / no posts in page.
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import re
 
 
 summary = "Tool for automated Instagram interactions"
-project_homepage = "https://github.com/timgrossmann/InstaPy"
+project_homepage = "https://github.com/InstaPy/InstaPy"
 here = path.abspath(path.dirname(__file__))
 
 


### PR DESCRIPTION


<!-- Did you know that we have a Discord channel ? Join us: https://discord.gg/FDETsht -->
<!-- Is this a Feature Request ? Please, check out our Wiki first https://github.com/timgrossmann/InstaPy/wiki -->
# Pull Request Template

## Description

switch project_homepage over to https://github.com/InstaPy/InstaPy as the old homepath (https://github.com/timgrossmann/InstaPy) is now a 404

Do not include any personal data.

Fixes # (issue)

## How Has This Been Tested?

Not tested

- [ ] Test

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have checked my code and corrected any misspellings
- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project, `black -t py34`
- [ ] My changes generate no new warnings
