### PR TITLE
Update xpath_compile.py file

### DIFF
--- a/instapy/xpath_compile.py
+++ b/instapy/xpath_compile.py
@@ -76,8 +76,8 @@ xpath["get_active_users"] = {
 }
 
 xpath["get_buttons_from_dialog"] = {
-    "follow_button": "//button[text()='Follow']",
-    "unfollow_button": "//button[text() = 'Following']",
+    "follow_button": "//button/div[text()='Follow']",
+    "unfollow_button": "//button/div[text() = 'Following']",
 }
 
 xpath["get_comment_input"] = {
@@ -95,12 +95,12 @@ xpath["get_comments_on_post"] = {
 xpath["get_cord_location"] = {"json_text": "//body"}
 
 xpath["get_following_status"] = {
-    "follow_button_XP": "//button[text()='Following' or \
-                                  text()='Requested' or \
-                                  text()='Follow' or \
-                                  text()='Follow Back' or \
-                                  text()='Unblock' and not(ancestor::*/@role = 'presentation')]",
-    "follow_span_XP_following": "//button/div/span[contains(@aria-label, 'Following')]",
+    "follow_button_XP": "//button/div[text()='Following' or \
+                                      text()='Requested' or \
+                                      text()='Follow' or \
+                                      text()='Follow Back' or \
+                                      text()='Unblock' and not(ancestor::*/@role = 'presentation')]",
+    "follow_span_XP_following": "//button/div/div/span[@aria-label='Following']",
 }
 
 xpath["get_follow_requests"] = {
@@ -108,7 +108,7 @@ xpath["get_follow_requests"] = {
     "view_more_button": "//button[text()='View More']",
 }
 
-xpath["get_given_user_followers"] = {"followers_link": "//ul/li[2]/a/span"}
+xpath["get_given_user_followers"] = {"followers_link": "//ul/li[2]/a/div/span"}
 
 xpath["get_given_user_following"] = {
     "all_following": "//a[contains(@href,'following')]/span",
@@ -116,7 +116,7 @@ xpath["get_given_user_following"] = {
     "following_link": '//a[@href="/{}/following/"]',
 }
 
-xpath["get_photo_urls_from_profile"] = {"photos_a_elems": "//div/a"}
+xpath["get_photo_urls_from_profile"] = {"photos_a_elems": "//a[starts-with(@href,'/p')]/@href"}
 
 xpath["get_links_for_location"] = {
     "top_elements": "//main/article/div[1]",
@@ -150,7 +150,7 @@ xpath["get_source_link"] = {
 
 xpath["get_users_through_dialog"] = {"find_dialog_box": "//body/div[4]/div/div[2]"}
 
-xpath["is_private_profile"] = {"is_private": '//h2[@class="_kcrwx"]'}
+xpath["is_private_profile"] = {"is_private": '//h2[@class="rkEop"]'}
 
 xpath["like_comment"] = {
     "comments_block": "//*[contains(@class,'EtaWk')]",
@@ -191,7 +191,7 @@ xpath["open_comment_section"] = {
 }
 
 xpath["unfollow"] = {
-    "following_link": "//ul/li[3]/a/span",
+    "following_link": "//ul/li[3]/a/div/span",
     "find_dialog_box": "//section/main/div[2]",
 }
 


### PR DESCRIPTION
Instagram made significant changes to their XPATH structure a couple of weeks ago. This pull request summarises the fixes I've identified which works for me.

**## Description**

Following Instagram updated their XPATH structures a few weeks ago, these fixes enable basic functionality to follow / unfollow public and private profiles and like images of public profiles. Full disclaimer - I started using InstaPy two weeks ago, but I am familiar with the XPATH language for other web scraping projects. The script runs fine on my end with these changes. 

**Fixes # (issue)**

`Could not find followers' link for ....`
`Grabbed 0 usernames from 'username' ...`
`--> Couldn't unfollow 'user'! ~user is inaccessible `
`Hey! Last follow is not verified out of an unexpected`
[unable to find image links when interacting with target users] (don't remember the error message)
[unable to retrieve follower of a target user] (don't remember the error message)

**## How Has This Been Tested?**

I tested the bot after every change to see if it fixed the error listed above. It seems some other users have successfully implemented these changes too. Full disclaimer - I have no warnings running the script now, but some people are still having issues as mentioned in the "issues" section. I suspect further changes are required to fully adjust the InstaPy module to accommodate the recent Instagram changes.
