### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ requests>=2.20.1
 selenium>=3.141.0
 setuptools_rust>=0.11.6
 six>=1.11.0
-urllib3>=1.24.1
+urllib3>=1.26.5
 webdriverdownloader>=1.1.0.3


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.24.1
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.24.1 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS